### PR TITLE
feat: 공연 후기 CRUD 및 별점 관리 구현

### DIFF
--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/controller/EventReviewController.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/controller/EventReviewController.java
@@ -1,0 +1,70 @@
+package com.pgms.apievent.eventreview.controller;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.pgms.apievent.eventreview.dto.request.EventReviewCreateRequest;
+import com.pgms.apievent.eventreview.dto.request.EventReviewUpdateRequest;
+import com.pgms.apievent.eventreview.dto.response.EventReviewResponse;
+import com.pgms.apievent.eventreview.service.EventReviewService;
+import com.pgms.coredomain.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/event-reviews")
+public class EventReviewController {
+
+	private final EventReviewService eventReviewService;
+
+	@PostMapping("/{eventId}")
+	public ResponseEntity<ApiResponse> createEventReview(
+		@PathVariable Long eventId,
+		@Valid @RequestBody EventReviewCreateRequest request) {
+		EventReviewResponse response = eventReviewService.createEventReview(eventId, request);
+		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+			.path("/{id}")
+			.buildAndExpand(response.id())
+			.toUri();
+		return ResponseEntity.created(location).body(ApiResponse.ok(response));
+	}
+
+	@PatchMapping("/{reviewId}")
+	public ResponseEntity<ApiResponse> updateEventReview(
+		@PathVariable Long reviewId,
+		@Valid @RequestBody EventReviewUpdateRequest request) {
+		EventReviewResponse response = eventReviewService.updateEventReview(reviewId, request);
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@GetMapping("/{reviewId}")
+	public ResponseEntity<ApiResponse> getEventReviewById(@PathVariable Long reviewId) {
+		EventReviewResponse response = eventReviewService.getEventReviewById(reviewId);
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@GetMapping("events/{eventId}")
+	public ResponseEntity<ApiResponse> getEventReviewsForEventByEventId(@PathVariable Long eventId) {
+		List<EventReviewResponse> responses = eventReviewService.getEventReviewsForEventByEventId(eventId);
+		return ResponseEntity.ok(ApiResponse.ok(responses));
+	}
+
+	@DeleteMapping("/{reviewId}")
+	public ResponseEntity<Void> deleteEventReviewById(@PathVariable Long reviewId) {
+		eventReviewService.deleteEventReviewById(reviewId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/request/EventReviewCreateRequest.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/request/EventReviewCreateRequest.java
@@ -1,0 +1,23 @@
+package com.pgms.apievent.eventreview.dto.request;
+
+import com.pgms.coredomain.domain.event.Event;
+import com.pgms.coredomain.domain.event.EventReview;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+public record EventReviewCreateRequest(
+	@PositiveOrZero(message = "리뷰 점수는 0이상의 값 이어야 합니다.")
+	int score,
+
+	@Size(max = 1000, message = "공연 리뷰 내용은 최대 1,000자까지 입력 가능 합니다.")
+	String content
+) {
+	public EventReview toEntity(Event event) {
+		return new EventReview(
+			score,
+			content,
+			event
+		);
+	}
+}

--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/request/EventReviewUpdateRequest.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/request/EventReviewUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.pgms.apievent.eventreview.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record EventReviewUpdateRequest(
+	@Size(max = 1000, message = "공연 리뷰 내용은 최대 1,000자까지 입력 가능 합니다.")
+	String content
+) {
+}

--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/response/EventReviewResponse.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/response/EventReviewResponse.java
@@ -1,0 +1,19 @@
+package com.pgms.apievent.eventreview.dto.response;
+
+import com.pgms.coredomain.domain.event.EventReview;
+
+public record EventReviewResponse(
+	Long id,
+	int score,
+	String content,
+	Long eventId
+) {
+	public static EventReviewResponse of(EventReview eventReview) {
+		return new EventReviewResponse(
+			eventReview.getId(),
+			eventReview.getScore(),
+			eventReview.getContent(),
+			eventReview.getEvent().getId()
+		);
+	}
+}

--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/service/EventReviewService.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/service/EventReviewService.java
@@ -1,0 +1,63 @@
+package com.pgms.apievent.eventreview.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pgms.apievent.eventreview.dto.request.EventReviewCreateRequest;
+import com.pgms.apievent.eventreview.dto.request.EventReviewUpdateRequest;
+import com.pgms.apievent.eventreview.dto.response.EventReviewResponse;
+import com.pgms.apievent.exception.CustomException;
+import com.pgms.apievent.exception.EventErrorCode;
+import com.pgms.coredomain.domain.event.Event;
+import com.pgms.coredomain.domain.event.EventReview;
+import com.pgms.coredomain.domain.event.repository.EventRepository;
+import com.pgms.coredomain.domain.event.repository.EventReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EventReviewService {
+
+	private final EventReviewRepository eventReviewRepository;
+	private final EventRepository eventRepository;
+
+	public EventReviewResponse createEventReview(Long eventId, EventReviewCreateRequest request) {
+		Event event = eventRepository.findById(eventId).
+			orElseThrow(() -> new CustomException(EventErrorCode.EVENT_NOT_FOUND));
+		EventReview eventReview = eventReviewRepository.save(request.toEntity(event));
+		// TODO : 동시성 고려 생각해보기
+		Double averageScore = eventReviewRepository.findAverageScoreByEvent(event.getId());
+		event.updateAverageScore(averageScore);
+		return EventReviewResponse.of(eventReview);
+	}
+
+	public EventReviewResponse updateEventReview(Long reviewId, EventReviewUpdateRequest request) {
+		EventReview eventReview = eventReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new CustomException(EventErrorCode.EVENT_REVIEW_NOT_FOUND));
+		eventReview.updateEventReview(request.content());
+		return EventReviewResponse.of(eventReview);
+	}
+
+	@Transactional(readOnly = true)
+	public EventReviewResponse getEventReviewById(Long reviewId) {
+		EventReview eventReview = eventReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new CustomException(EventErrorCode.EVENT_REVIEW_NOT_FOUND));
+		return EventReviewResponse.of(eventReview);
+	}
+
+	@Transactional(readOnly = true)
+	public List<EventReviewResponse> getEventReviewsForEventByEventId(Long eventId) {
+		List<EventReview> eventReviews = eventReviewRepository.findEventReviewsByEventId(eventId);
+		return eventReviews.stream().map(EventReviewResponse::of).toList();
+	}
+
+	public void deleteEventReviewById(Long reviewId) {
+		EventReview eventReview = eventReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new CustomException(EventErrorCode.EVENT_REVIEW_NOT_FOUND));
+		eventReviewRepository.delete(eventReview);
+	}
+}

--- a/api/api-event/src/main/java/com/pgms/apievent/exception/EventErrorCode.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/exception/EventErrorCode.java
@@ -13,7 +13,8 @@ public enum EventErrorCode {
 	ALREADY_EXIST_EVENT("DUPLICATE EVENT", HttpStatus.CONFLICT, "이미 존재하는 공연입니다."),
 	EVENT_TIME_NOT_FOUND("EVENT TIME NOT FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 회차입니다."),
 	ALREADY_EXIST_EVENT_TIME("EVENT TIME ALREADY EXISTS", HttpStatus.CONFLICT, "공연에 대한 회차가 이미 존재합니다."),
-	VALIDATION_FAILED("VALIDATION FAILED", HttpStatus.BAD_REQUEST, "입력값에 대한 검증에 실패했습니다.");
+	VALIDATION_FAILED("VALIDATION FAILED", HttpStatus.BAD_REQUEST, "입력값에 대한 검증에 실패했습니다."),
+	EVENT_REVIEW_NOT_FOUND("EVENT REVIEW NOT FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 공연 리뷰입니다.");
 
 	private final String errorCode;
 	private final HttpStatus status;

--- a/api/api-event/src/test/java/com/pgms/apievent/eventreview/service/EventReviewServiceTest.java
+++ b/api/api-event/src/test/java/com/pgms/apievent/eventreview/service/EventReviewServiceTest.java
@@ -1,0 +1,70 @@
+package com.pgms.apievent.eventreview.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.pgms.apievent.eventreview.dto.request.EventReviewCreateRequest;
+import com.pgms.apievent.factory.event.EventFactory;
+import com.pgms.apievent.factory.eventhall.EventHallFactory;
+import com.pgms.coredomain.domain.event.Event;
+import com.pgms.coredomain.domain.event.EventHall;
+import com.pgms.coredomain.domain.event.repository.EventHallRepository;
+import com.pgms.coredomain.domain.event.repository.EventRepository;
+import com.pgms.coredomain.domain.event.repository.EventReviewRepository;
+
+@SpringBootTest
+class EventReviewServiceTest {
+
+	private static final int REQUEST_NUMBER = 8;
+	private static final double AVERAGE_REVIEW_SCORE = 3.5;
+
+	@Autowired
+	private EventReviewService eventReviewService;
+
+	@Autowired
+	private EventReviewRepository eventReviewRepository;
+
+	@Autowired
+	private EventRepository eventRepository;
+
+	@Autowired
+	private EventHallRepository eventHallRepository;
+
+	private Event event;
+
+	@BeforeEach
+	void setUp() {
+		EventHall eventHall = EventHallFactory.createEventHall();
+		eventHallRepository.save(eventHall);
+		event = eventRepository.save(EventFactory.createEvent(eventHall));
+	}
+
+	@AfterEach
+	void tearDown() {
+		eventReviewRepository.deleteAll();
+	}
+
+	@Test
+	void 공연_리뷰_생성_테스트() {
+		// Given
+		List<EventReviewCreateRequest> requestList = IntStream.range(0, REQUEST_NUMBER)
+			.mapToObj(i -> new EventReviewCreateRequest(i, "리뷰 내용 " + i))
+			.toList();
+
+		// When
+		IntStream.range(0, REQUEST_NUMBER)
+			.forEach(i -> eventReviewService.createEventReview(event.getId(), requestList.get(i)));
+		Event savedEvent = eventRepository.findById(event.getId()).get();
+
+		// Then
+		assertThat(savedEvent.getAverageScore()).isEqualTo(AVERAGE_REVIEW_SCORE);
+	}
+}

--- a/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/Event.java
+++ b/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/Event.java
@@ -56,6 +56,9 @@ public class Event extends BaseEntity {
 	@Column(name = "genre")
 	@Enumerated(value = EnumType.STRING)
 	private GenreType genreType;
+	
+	@Column(name = "average_score")
+	private Double averageScore = 0.0;
 
 	@Lob
 	@Column(name = "thumbnail")
@@ -97,5 +100,9 @@ public class Event extends BaseEntity {
 		this.genreType = eventEdit.genreType();
 		this.thumbnail = eventEdit.thumbnail();
 		this.eventHall = eventEdit.eventHall();
+	}
+
+	public void updateAverageScore(Double averageScore) {
+		this.averageScore = averageScore;
 	}
 }

--- a/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/EventReview.java
+++ b/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/EventReview.java
@@ -1,8 +1,23 @@
 package com.pgms.coredomain.domain.event;
 
 import com.pgms.coredomain.domain.common.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -11,19 +26,29 @@ import lombok.*;
 @Table(name = "event_review")
 public class EventReview extends BaseEntity {
 
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(name = "score")
-    private Integer score;
+	@Column(name = "score")
+	private int score;
 
-    @Lob
-    @Column(name = "content")
-    private String content;
+	@Lob
+	@Column(name = "content")
+	private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private Event event;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "event_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+	private Event event;
+
+	public EventReview(Integer score, String content, Event event) {
+		this.score = score;
+		this.content = content;
+		this.event = event;
+	}
+
+	public void updateEventReview(String content) {
+		this.content = content;
+	}
 }

--- a/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/repository/EventReviewRepository.java
+++ b/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/repository/EventReviewRepository.java
@@ -1,0 +1,17 @@
+package com.pgms.coredomain.domain.event.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.pgms.coredomain.domain.event.EventReview;
+
+public interface EventReviewRepository extends JpaRepository<EventReview, Long> {
+	@Query("SELECT er FROM EventReview er WHERE er.event.id = :eventId")
+	List<EventReview> findEventReviewsByEventId(@Param("eventId") Long eventId);
+
+	@Query("SELECT ROUND(AVG(er.score), 1) FROM EventReview er WHERE er.event.id = :eventId")
+	Double findAverageScoreByEvent(@Param("eventId") Long eventId);
+}


### PR DESCRIPTION
## 구현 기능
- 공연 후기 CRUD 및 별점 관리 기능 구현

## 상세 기능

- [x] 공연 후기 작성 (/api/v1/event-reviews/{eventId})
- [x] 공연 후기 수정 (/api/v1/event-reviews/{reviewId})
- [x] 공연 후기 단건 조회 (/api/v1/event-reviews/{reviewId})
- [x] 특정 공연에 대한 후기 전체 조회 (/api/v1/event-reviews/events/{eventId})
- [x] 공연 후기 평점 평균 관리 기능 -> 후기 작성 시에 함께 계산 및 관리되도록 구현

resolve: #33 
