### PR TITLE
fix: #175 공연 목록 조회 - 랭킹순 쿼리 수정

### DIFF
--- a/api/api-event/http/event.http
+++ b/api/api-event/http/event.http
@@ -3,27 +3,29 @@ POST http://localhost:8080/api/v1/events
 Content-Type: application/json
 
 {
-  "title": "엘라스틱 서치",
+  "title": "엘라스틱 서치3",
   "description": "test",
   "runningTime": 100,
   "startedAt": "2024-01-05T12:00:00",
   "endedAt": "2024-01-06T12:00:00",
   "viewRating": "12",
   "genreType": "CONCERT",
+  "bookingStartedAt": "2024-01-05T12:00:00",
+  "bookingEndedAt": "2025-01-06T12:00:00",
   "eventHallId": 1
 }
 
 ### 공연 아이디로 조회
-GET http://localhost:8080/api/v1/events/1
+GET http://localhost:8080/api/v1/events/2
 
 ### 공연 목록 - 랭킹
 GET http://localhost:8080/api/v1/events/sort/ranking?page=1&size=10&genreType=CONCERT&dateOffset=7
 
 ### 공연 목록 - 리뷰순
-GET http://localhost:8080/api/v1/events/sort/review?page=1&size=10&genreType=CONCERT&dateOffset=7
+GET http://localhost:8080/api/v1/events/sort/review?page=1&size=10&genreType=CONCERT
 
 ### 공연 목록 - 예약마감일자순
-GET http://localhost:8080/api/v1/events/sort/ended-at?page=1&size=10&genreType=CONCERT&dateOffset=7
+GET http://localhost:8080/api/v1/events/sort/ended-at?page=1&size=10&genreType=CONCERT
 
 ### 공연 수정
 PUT http://localhost:8080/api/v1/events/2

--- a/api/api-event/src/main/java/com/pgms/apievent/event/dto/request/EventCreateRequest.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/event/dto/request/EventCreateRequest.java
@@ -33,9 +33,13 @@ public record EventCreateRequest(
 	@NotNull(message = "공연 장르 타입은 필수 입력값 입니다.")
 	GenreType genreType,
 
+	LocalDateTime bookingStartedAt,
+
+	LocalDateTime bookingEndedAt,
+
 	@NotNull(message = "이벤트 홀 ID는 필수 입력값 입니다.")
 	Long eventHallId) {
-	
+
 	public Event toEntity(EventHall eventHall) {
 		return Event.builder()
 			.title(title)
@@ -46,6 +50,8 @@ public record EventCreateRequest(
 			.viewRating(viewRating)
 			.genreType(genreType)
 			.thumbnail("defaultThumbnail.jpg")
+			.bookingStartedAt(bookingStartedAt)
+			.bookingEndedAt(bookingEndedAt)
 			.eventHall(eventHall)
 			.build();
 	}

--- a/api/api-event/src/main/java/com/pgms/apievent/event/dto/request/EventUpdateRequest.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/event/dto/request/EventUpdateRequest.java
@@ -23,8 +23,10 @@ EventUpdateRequest(
 	@Positive(message = "공연 러닝 타임은 0보다 큰 값 이어야 합니다.")
 	int runningTime,
 
+	@Nullable
 	LocalDateTime startedAt,
 
+	@Nullable
 	LocalDateTime endedAt,
 
 	@NotBlank(message = "관람 등급은 필수 입력값 입니다.")

--- a/api/api-event/src/main/java/com/pgms/apievent/event/dto/response/EventResponse.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/event/dto/response/EventResponse.java
@@ -12,6 +12,8 @@ public record EventResponse(
 	String rating,
 	String genreType,
 	String thumbnail,
+	String bookingStartedAt,
+	String bookingEndedAt,
 	String eventHall,
 	Double averageScore
 ) {
@@ -26,6 +28,8 @@ public record EventResponse(
 			event.getViewRating(),
 			event.getGenreType().getDescription(),
 			event.getThumbnail(),
+			event.getBookingStartedAt().toString(),
+			event.getBookingEndedAt().toString(),
 			event.getEventHall().getName(),
 			event.getAverageScore()
 		);

--- a/api/api-event/src/main/java/com/pgms/apievent/event/repository/EventCustomRepositoryImpl.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/event/repository/EventCustomRepositoryImpl.java
@@ -39,11 +39,11 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
 			.with(LocalTime.MIN);
 
 		List<EventResponse> content = jpaQueryFactory.selectFrom(event)
-			.join(eventTime)
+			.leftJoin(eventTime)
 			.on(eventTime.event.eq(event))
 			.leftJoin(booking)
 			.on(booking.time.eq(eventTime))
-			.where(event.genreType.eq(genre), booking.createdAt.goe(cmpDate))
+			.where(event.genreType.eq(genre), booking.createdAt.coalesce(cmpDate).goe(cmpDate))
 			.groupBy(event.id)
 			.orderBy(booking.count().desc())
 			.offset(offset)


### PR DESCRIPTION
## 구현 기능
- 공연 목록 조회 - 랭킹순 쿼리 수정

## 상세 내용
- 공연 목록 조회 - 랭킹순 쿼리 수정 (join -> left Join)
- 공연 생성 DTO , 응답 DTO 내의 bookingStartedAt, bookingEndedAt 컬럼 추가

resolve: #175 
