### PR TITLE
feat: 공연 후기 작성자(회원) 추가

### DIFF
--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/controller/EventReviewController.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/controller/EventReviewController.java
@@ -19,6 +19,7 @@ import com.pgms.apievent.eventreview.dto.request.EventReviewUpdateRequest;
 import com.pgms.apievent.eventreview.dto.response.EventReviewResponse;
 import com.pgms.apievent.eventreview.service.EventReviewService;
 import com.pgms.coredomain.response.ApiResponse;
+import com.pgms.coresecurity.security.resolver.CurrentAccount;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,9 +33,10 @@ public class EventReviewController {
 
 	@PostMapping("/{eventId}")
 	public ResponseEntity<ApiResponse> createEventReview(
+		@CurrentAccount Long memberId,
 		@PathVariable Long eventId,
 		@Valid @RequestBody EventReviewCreateRequest request) {
-		EventReviewResponse response = eventReviewService.createEventReview(eventId, request);
+		EventReviewResponse response = eventReviewService.createEventReview(memberId, eventId, request);
 		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
 			.path("/{id}")
 			.buildAndExpand(response.id())
@@ -45,9 +47,10 @@ public class EventReviewController {
 
 	@PatchMapping("/{reviewId}")
 	public ResponseEntity<ApiResponse> updateEventReview(
+		@CurrentAccount Long memberId,
 		@PathVariable Long reviewId,
 		@Valid @RequestBody EventReviewUpdateRequest request) {
-		EventReviewResponse response = eventReviewService.updateEventReview(reviewId, request);
+		EventReviewResponse response = eventReviewService.updateEventReview(memberId, reviewId, request);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 
@@ -64,8 +67,8 @@ public class EventReviewController {
 	}
 
 	@DeleteMapping("/{reviewId}")
-	public ResponseEntity<Void> deleteEventReviewById(@PathVariable Long reviewId) {
-		eventReviewService.deleteEventReviewById(reviewId);
+	public ResponseEntity<Void> deleteEventReviewById(@CurrentAccount Long memberId, @PathVariable Long reviewId) {
+		eventReviewService.deleteEventReviewById(memberId, reviewId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/request/EventReviewCreateRequest.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/dto/request/EventReviewCreateRequest.java
@@ -2,6 +2,7 @@ package com.pgms.apievent.eventreview.dto.request;
 
 import com.pgms.coredomain.domain.event.Event;
 import com.pgms.coredomain.domain.event.EventReview;
+import com.pgms.coredomain.domain.member.Member;
 
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -12,12 +13,13 @@ public record EventReviewCreateRequest(
 
 	@Size(max = 1000, message = "공연 리뷰 내용은 최대 1,000자까지 입력 가능 합니다.")
 	String content) {
-	
-	public EventReview toEntity(Event event) {
+
+	public EventReview toEntity(Event event, Member member) {
 		return new EventReview(
 			score,
 			content,
-			event
+			event,
+			member
 		);
 	}
 }

--- a/api/api-event/src/test/java/com/pgms/apievent/eventreview/service/EventReviewServiceTest.java
+++ b/api/api-event/src/test/java/com/pgms/apievent/eventreview/service/EventReviewServiceTest.java
@@ -24,6 +24,9 @@ import com.pgms.coredomain.domain.event.EventReview;
 import com.pgms.coredomain.domain.event.repository.EventHallRepository;
 import com.pgms.coredomain.domain.event.repository.EventRepository;
 import com.pgms.coredomain.domain.event.repository.EventReviewRepository;
+import com.pgms.coredomain.domain.member.Member;
+import com.pgms.coredomain.domain.member.enums.Gender;
+import com.pgms.coredomain.domain.member.repository.MemberRepository;
 
 @SpringBootTest
 @ContextConfiguration(classes = EventTestConfig.class)
@@ -44,6 +47,9 @@ class EventReviewServiceTest {
 	@Autowired
 	private EventHallRepository eventHallRepository;
 
+	@Autowired
+	private MemberRepository memberRepository;
+
 	@AfterEach
 	void tearDown() {
 		eventReviewRepository.deleteAll();
@@ -54,10 +60,22 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
+		Member member = memberRepository.save(Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build());
+
 		EventReviewCreateRequest request = new EventReviewCreateRequest(5, "공연이 너무 재밌어요 !");
 
 		// When
-		EventReviewResponse response = eventReviewService.createEventReview(event.getId(), request);
+		EventReviewResponse response = eventReviewService.createEventReview(member.getId(), event.getId(), request);
 
 		// Then
 		assertThat(response.eventId()).isEqualTo(event.getId());
@@ -70,13 +88,25 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
+		Member member = memberRepository.save(Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build());
+
 		List<EventReviewCreateRequest> requestList = IntStream.range(0, REQUEST_NUMBER)
 			.mapToObj(i -> new EventReviewCreateRequest(i, "리뷰 내용 " + i))
 			.toList();
 
 		// When
 		IntStream.range(0, REQUEST_NUMBER)
-			.forEach(i -> eventReviewService.createEventReview(event.getId(), requestList.get(i)));
+			.forEach(i -> eventReviewService.createEventReview(member.getId(), event.getId(), requestList.get(i)));
 		Event savedEvent = eventRepository.findById(event.getId()).get();
 
 		// Then
@@ -88,12 +118,25 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event));
+		Member member = memberRepository.save(Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build());
+
+		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event, member));
 
 		EventReviewUpdateRequest request = new EventReviewUpdateRequest("공연 후기 수정입니다~!");
 
 		// When
-		EventReviewResponse response = eventReviewService.updateEventReview(eventReview.getId(), request);
+		EventReviewResponse response = eventReviewService.updateEventReview(member.getId(), eventReview.getId(),
+			request);
 
 		// Then
 		assertThat(response.content()).isEqualTo(request.content());
@@ -104,7 +147,19 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event));
+		Member member = memberRepository.save(Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build());
+
+		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event, member));
 		Long eventReviewId = eventReview.getId();
 
 		// When
@@ -121,8 +176,20 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
+		Member member = memberRepository.save(Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build());
+
 		IntStream.range(0, REQUEST_NUMBER)
-			.forEach(i -> eventReviewRepository.save(new EventReview(i, "리뷰 내용 " + i, event)));
+			.forEach(i -> eventReviewRepository.save(new EventReview(i, "리뷰 내용 " + i, event, member)));
 
 		// When
 		List<EventReviewResponse> responses = eventReviewService.getEventReviewsForEventByEventId(event.getId());
@@ -136,10 +203,22 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event));
+		Member member = memberRepository.save(Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build());
+
+		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event, member));
 
 		// When
-		eventReviewService.deleteEventReviewById(eventReview.getId());
+		eventReviewService.deleteEventReviewById(member.getId(), eventReview.getId());
 
 		// Then
 		assertThat(eventReviewRepository.findAll()).hasSize(0);

--- a/api/api-event/src/test/java/com/pgms/apievent/eventreview/service/EventReviewServiceTest.java
+++ b/api/api-event/src/test/java/com/pgms/apievent/eventreview/service/EventReviewServiceTest.java
@@ -18,6 +18,7 @@ import com.pgms.apievent.eventreview.dto.response.EventReviewResponse;
 import com.pgms.apievent.factory.event.EventFactory;
 import com.pgms.apievent.factory.eventhall.EventHallFactory;
 import com.pgms.apievent.factory.eventreview.EventReviewFactory;
+import com.pgms.apievent.factory.member.MemberFactory;
 import com.pgms.coredomain.domain.event.Event;
 import com.pgms.coredomain.domain.event.EventHall;
 import com.pgms.coredomain.domain.event.EventReview;
@@ -25,7 +26,6 @@ import com.pgms.coredomain.domain.event.repository.EventHallRepository;
 import com.pgms.coredomain.domain.event.repository.EventRepository;
 import com.pgms.coredomain.domain.event.repository.EventReviewRepository;
 import com.pgms.coredomain.domain.member.Member;
-import com.pgms.coredomain.domain.member.enums.Gender;
 import com.pgms.coredomain.domain.member.repository.MemberRepository;
 
 @SpringBootTest
@@ -60,17 +60,7 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		Member member = memberRepository.save(Member.builder()
-			.email("test@naver.com")
-			.password("encodedPassword")
-			.name("tester")
-			.phoneNumber("01011112222")
-			.birthDate("19990926")
-			.gender(Gender.MALE)
-			.streetAddress("서울특별시 송파구 올림픽로 300")
-			.detailAddress("롯데월드타워앤드롯데월드몰")
-			.zipCode("05551")
-			.build());
+		Member member = memberRepository.save(MemberFactory.createMember());
 
 		EventReviewCreateRequest request = new EventReviewCreateRequest(5, "공연이 너무 재밌어요 !");
 
@@ -88,17 +78,7 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		Member member = memberRepository.save(Member.builder()
-			.email("test@naver.com")
-			.password("encodedPassword")
-			.name("tester")
-			.phoneNumber("01011112222")
-			.birthDate("19990926")
-			.gender(Gender.MALE)
-			.streetAddress("서울특별시 송파구 올림픽로 300")
-			.detailAddress("롯데월드타워앤드롯데월드몰")
-			.zipCode("05551")
-			.build());
+		Member member = memberRepository.save(MemberFactory.createMember());
 
 		List<EventReviewCreateRequest> requestList = IntStream.range(0, REQUEST_NUMBER)
 			.mapToObj(i -> new EventReviewCreateRequest(i, "리뷰 내용 " + i))
@@ -118,17 +98,7 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		Member member = memberRepository.save(Member.builder()
-			.email("test@naver.com")
-			.password("encodedPassword")
-			.name("tester")
-			.phoneNumber("01011112222")
-			.birthDate("19990926")
-			.gender(Gender.MALE)
-			.streetAddress("서울특별시 송파구 올림픽로 300")
-			.detailAddress("롯데월드타워앤드롯데월드몰")
-			.zipCode("05551")
-			.build());
+		Member member = memberRepository.save(MemberFactory.createMember());
 
 		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event, member));
 
@@ -147,17 +117,7 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		Member member = memberRepository.save(Member.builder()
-			.email("test@naver.com")
-			.password("encodedPassword")
-			.name("tester")
-			.phoneNumber("01011112222")
-			.birthDate("19990926")
-			.gender(Gender.MALE)
-			.streetAddress("서울특별시 송파구 올림픽로 300")
-			.detailAddress("롯데월드타워앤드롯데월드몰")
-			.zipCode("05551")
-			.build());
+		Member member = memberRepository.save(MemberFactory.createMember());
 
 		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event, member));
 		Long eventReviewId = eventReview.getId();
@@ -176,17 +136,7 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		Member member = memberRepository.save(Member.builder()
-			.email("test@naver.com")
-			.password("encodedPassword")
-			.name("tester")
-			.phoneNumber("01011112222")
-			.birthDate("19990926")
-			.gender(Gender.MALE)
-			.streetAddress("서울특별시 송파구 올림픽로 300")
-			.detailAddress("롯데월드타워앤드롯데월드몰")
-			.zipCode("05551")
-			.build());
+		Member member = memberRepository.save(MemberFactory.createMember());
 
 		IntStream.range(0, REQUEST_NUMBER)
 			.forEach(i -> eventReviewRepository.save(new EventReview(i, "리뷰 내용 " + i, event, member)));
@@ -203,17 +153,7 @@ class EventReviewServiceTest {
 		// Given
 		EventHall eventHall = eventHallRepository.save(EventHallFactory.createEventHall());
 		Event event = eventRepository.save(EventFactory.createEvent(eventHall));
-		Member member = memberRepository.save(Member.builder()
-			.email("test@naver.com")
-			.password("encodedPassword")
-			.name("tester")
-			.phoneNumber("01011112222")
-			.birthDate("19990926")
-			.gender(Gender.MALE)
-			.streetAddress("서울특별시 송파구 올림픽로 300")
-			.detailAddress("롯데월드타워앤드롯데월드몰")
-			.zipCode("05551")
-			.build());
+		Member member = memberRepository.save(MemberFactory.createMember());
 
 		EventReview eventReview = eventReviewRepository.save(EventReviewFactory.createEventReview(event, member));
 

--- a/api/api-event/src/test/java/com/pgms/apievent/factory/eventreview/EventReviewFactory.java
+++ b/api/api-event/src/test/java/com/pgms/apievent/factory/eventreview/EventReviewFactory.java
@@ -2,14 +2,16 @@ package com.pgms.apievent.factory.eventreview;
 
 import com.pgms.coredomain.domain.event.Event;
 import com.pgms.coredomain.domain.event.EventReview;
+import com.pgms.coredomain.domain.member.Member;
 
 public class EventReviewFactory {
 
-	public static EventReview createEventReview(Event event) {
+	public static EventReview createEventReview(Event event, Member member) {
 		return new EventReview(
 			4,
 			"공연 후기입니다.",
-			event
+			event,
+			member
 		);
 	}
 }

--- a/api/api-event/src/test/java/com/pgms/apievent/factory/member/MemberFactory.java
+++ b/api/api-event/src/test/java/com/pgms/apievent/factory/member/MemberFactory.java
@@ -1,0 +1,20 @@
+package com.pgms.apievent.factory.member;
+
+import com.pgms.coredomain.domain.member.Member;
+import com.pgms.coredomain.domain.member.enums.Gender;
+
+public class MemberFactory {
+	public static Member createMember() {
+		return Member.builder()
+			.email("test@naver.com")
+			.password("encodedPassword")
+			.name("tester")
+			.phoneNumber("01011112222")
+			.birthDate("19990926")
+			.gender(Gender.MALE)
+			.streetAddress("서울특별시 송파구 올림픽로 300")
+			.detailAddress("롯데월드타워앤드롯데월드몰")
+			.zipCode("05551")
+			.build();
+	}
+}

--- a/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/EventReview.java
+++ b/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/EventReview.java
@@ -1,6 +1,7 @@
 package com.pgms.coredomain.domain.event;
 
 import com.pgms.coredomain.domain.common.BaseEntity;
+import com.pgms.coredomain.domain.member.Member;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -40,10 +41,15 @@ public class EventReview extends BaseEntity {
 	@JoinColumn(name = "event_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private Event event;
 
-	public EventReview(Integer score, String content, Event event) {
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+	private Member member;
+
+	public EventReview(Integer score, String content, Event event, Member member) {
 		this.score = score;
 		this.content = content;
 		this.event = event;
+		this.member = member;
 	}
 
 	public void updateEventReview(String content) {


### PR DESCRIPTION
## 구현 기능
- 공연 후기 작성자(회원) 추가

## 기능 상세
- 공연 후기 부분에 후기 작성자 추가
- 공연 후기 작성 부분에 작성자 로직 추가
- 공연 후기 수정 부분에 작성자 로직 추가
- 공연 후기 삭제 부분에 작성자 로직 추가

## 참고 사항
- 후기 수정 및 삭제 부분에서는 현재 로그인한 회원과 후기 작성자가 일치하는지 검증하는 로직이 필요

resolve: #182 
