### PR TITLE
feat: 공연 후기 회원 검증 로직 추가

### DIFF
--- a/api/api-event/src/main/java/com/pgms/apievent/eventreview/service/EventReviewService.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/eventreview/service/EventReviewService.java
@@ -42,9 +42,9 @@ public class EventReviewService {
 	}
 
 	public EventReviewResponse updateEventReview(Long memberId, Long reviewId, EventReviewUpdateRequest request) {
-		// TODO : 작성자와 현재 로그인한 사람이 일치하는지 검증 로직 필요
 		Member member = getMember(memberId);
 		EventReview eventReview = getEventReview(reviewId);
+		validateReviewer(eventReview, member);
 		eventReview.updateEventReview(request.content());
 		return EventReviewResponse.of(eventReview);
 	}
@@ -64,9 +64,9 @@ public class EventReviewService {
 	}
 
 	public void deleteEventReviewById(Long memberId, Long reviewId) {
-		// TODO : 작성자와 현재 로그인한 사람이 일치하는지 검증 로직 필요
 		Member member = getMember(memberId);
 		EventReview eventReview = getEventReview(reviewId);
+		validateReviewer(eventReview, member);
 		eventReviewRepository.delete(eventReview);
 	}
 
@@ -78,5 +78,11 @@ public class EventReviewService {
 	private Member getMember(Long memberId) {
 		return memberRepository.findById(memberId)
 			.get();
+	}
+
+	private void validateReviewer(EventReview eventReview, Member member) {
+		if (!eventReview.isSameReviewer(member)) {
+			throw new EventException(REVIEWER_MISMATCH_EXCEPTION);
+		}
 	}
 }

--- a/api/api-event/src/main/java/com/pgms/apievent/exception/EventErrorCode.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/exception/EventErrorCode.java
@@ -17,6 +17,7 @@ public enum EventErrorCode implements BaseErrorCode {
 	EVENT_TIME_NOT_FOUND("EVENT TIME NOT FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 회차입니다."),
 	ALREADY_EXIST_EVENT_TIME("EVENT TIME ALREADY EXISTS", HttpStatus.CONFLICT, "공연에 대한 회차가 이미 존재합니다."),
 	VALIDATION_FAILED("VALIDATION FAILED", HttpStatus.BAD_REQUEST, "입력값에 대한 검증에 실패했습니다."),
+	REVIEWER_MISMATCH_EXCEPTION("REVIEWER MISMATCH", HttpStatus.BAD_REQUEST, "리뷰 작성자가 일치하지 않습니다."),
 	EVENT_REVIEW_NOT_FOUND("EVENT REVIEW NOT FOUND", HttpStatus.NOT_FOUND, "존재하지 않는 공연 리뷰입니다."),
 	UNSUPPORTED_FILE_EXTENSION("UNSUPPORTED FILE EXTENSION", HttpStatus.BAD_REQUEST, "지원되지 않는 파일 확장자입니다."),
 	S3_UPLOAD_FAILED_EXCEPTION("S3 UPLOAD FAILED", HttpStatus.INTERNAL_SERVER_ERROR, "S3에 파일 업로드를 실패했습니다.");

--- a/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/EventReview.java
+++ b/core/core-domain/src/main/java/com/pgms/coredomain/domain/event/EventReview.java
@@ -55,4 +55,11 @@ public class EventReview extends BaseEntity {
 	public void updateEventReview(String content) {
 		this.content = content;
 	}
+
+	public boolean isSameReviewer(Member member) {
+		if (member != null) {
+			return this.member.equals(member);
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
## 구현 기능
- 공연 후기 작성자(회원)에 대한 검증 로직 추가

## 요약
- 공연 후기 작성자가 현재 로그인한 유저와 일치하는지 검증
- 후기 수정, 삭제 처리 부분에 적용

resolve: #188 

