### PR TITLE
fix: booking, event 모듈 SecurityCustomException 예외처리

### DIFF
--- a/api/api-booking/src/main/java/com/pgms/apibooking/common/exception/BookingExceptionHandler.java
+++ b/api/api-booking/src/main/java/com/pgms/apibooking/common/exception/BookingExceptionHandler.java
@@ -15,8 +15,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.pgms.coredomain.domain.common.BaseErrorCode;
 import com.pgms.coredomain.domain.common.BookingErrorCode;
 import com.pgms.coredomain.response.ErrorResponse;
+import com.pgms.coresecurity.security.exception.SecurityCustomException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -67,5 +69,12 @@ public class BookingExceptionHandler extends ResponseEntityExceptionHandler {
 		ErrorResponse response = ex.getErrorCode().getErrorResponse();
 		log.warn("Booking Exception Occurred : {}", response.getErrorMessage());
 		return ResponseEntity.status(ex.getErrorCode().getStatus()).body(response);
+	}
+
+	@ExceptionHandler(SecurityCustomException.class)
+	protected ResponseEntity<ErrorResponse> handleSecurityCustomException(SecurityCustomException ex) {
+		log.warn("SecurityCustomException Occurred: {}", ex);
+		BaseErrorCode errorCode = ex.getErrorCode();
+		return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
 	}
 }

--- a/api/api-event/src/main/java/com/pgms/apievent/exception/EventGlobalExceptionHandler.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/exception/EventGlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.pgms.apievent.exception;
 
-import com.pgms.coredomain.domain.common.BaseErrorCode;
-import com.pgms.coredomain.response.ErrorResponse;
-import lombok.extern.slf4j.Slf4j;
+import static com.pgms.apievent.exception.EventErrorCode.*;
+
+import java.util.List;
+import java.util.Objects;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -14,10 +16,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.pgms.coredomain.domain.common.BaseErrorCode;
 import com.pgms.coredomain.response.ErrorResponse;
 import com.pgms.coresecurity.security.exception.SecurityCustomException;
-import java.util.List;
-import java.util.Objects;
 
-import static com.pgms.apievent.exception.EventErrorCode.VALIDATION_FAILED;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -48,8 +48,9 @@ public class EventGlobalExceptionHandler {
 		log.warn(">>>>> SecurityCustomException : {}", ex);
 		BaseErrorCode errorCode = ex.getErrorCode();
 		return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
+	}
 
-    @ExceptionHandler(Exception.class)
+	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
 		log.error(">>>>> Internal Server Error : {}", ex);
 		ErrorResponse errorResponse = new ErrorResponse("INTERNAL SERVER ERROR", ex.getMessage());

--- a/api/api-event/src/main/java/com/pgms/apievent/exception/EventGlobalExceptionHandler.java
+++ b/api/api-event/src/main/java/com/pgms/apievent/exception/EventGlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.pgms.coredomain.domain.common.BaseErrorCode;
 import com.pgms.coredomain.response.ErrorResponse;
+import com.pgms.coresecurity.security.exception.SecurityCustomException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,5 +48,12 @@ public class EventGlobalExceptionHandler {
 		ErrorResponse errorResponse = new ErrorResponse(VALIDATION_FAILED.getErrorCode(), errorMessage);
 		fieldErrors.forEach(error -> errorResponse.addValidation(error.getField(), error.getDefaultMessage()));
 		return ResponseEntity.status(ex.getStatusCode()).body(errorResponse);
+	}
+
+	@ExceptionHandler(SecurityCustomException.class)
+	protected ResponseEntity<ErrorResponse> handleSecurityCustomException(SecurityCustomException ex) {
+		log.warn(">>>>> SecurityCustomException : {}", ex);
+		BaseErrorCode errorCode = ex.getErrorCode();
+		return ResponseEntity.status(errorCode.getStatus()).body(errorCode.getErrorResponse());
 	}
 }

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/resolver/CurrentAccountArgumentResolver.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/resolver/CurrentAccountArgumentResolver.java
@@ -3,6 +3,7 @@ package com.pgms.coresecurity.security.resolver;
 import java.util.Objects;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -27,13 +28,13 @@ public class CurrentAccountArgumentResolver implements HandlerMethodArgumentReso
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
 		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		checkAuthenticated(authentication);
+		validateAuthentication(authentication);
 		UserDetailsImpl userDetails = (UserDetailsImpl)authentication.getPrincipal();
 		return userDetails.getId();
 	}
 
-	private void checkAuthenticated(Authentication authentication) {
-		if (Objects.isNull(authentication)) {
+	private void validateAuthentication(Authentication authentication) {
+		if (Objects.isNull(authentication) || !(authentication instanceof UsernamePasswordAuthenticationToken)) {
 			throw new SecurityCustomException(SecurityErrorCode.UNAUTHORIZED);
 		}
 	}


### PR DESCRIPTION
## 변경 사항
booking, event 모듈 SecurityCustomException 예외처리
- CurrentAccountArgumentResolver에서 예외 발생시 각 모듈의 GlobalExceptionHandler에서 처리하도록 수정

## 상황
예매 취소 api 호출시 Authorization 헤더값이 없을 경우 아래 예외 발생
POST http://localhost:8082/api/v1/bookings/1704704631741/cancel

> 2024-01-10T10:48:01.939+09:00 ERROR 22928 --- [nio-8082-exec-1] o.a.c.c.C.[.[.[/].[dispatcherServlet] : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.ClassCastException: class java.lang.String cannot be cast to class com.pgms.coresecurity.security.service.UserDetailsImpl (java.lang.String is in module java.base of loader 'bootstrap'; com.pgms.coresecurity.security.service.UserDetailsImpl is in unnamed module of loader 'app')] with root cause

## 분석
@CurrentAccount 를 매개변수로 가지는 컨트롤러에서 Authorization 없이 호출되면
SecurityContextHolder의 Authentication에는 AnonymousAuthenticationToken이 저장되고, getPrinciple에는 "anonymousUser" 라는 String 값이 들어있음
String 값은 UserDetailsImpl로 형변환 될 수 없기 때문에 위 내용의 예외 발생

## 해결
- CurrentAccountArgumentResolver 에서 SecurityContextHolder의 Authentication이 UsernamePasswordAuthenticationToken 이 아니면 예외 발생하도록 수정
- api-event, api-booking의 ExceptionHandler에 SecurityCustomException 핸들러 메소드 추가


resolve: #196 
