### PR TITLE
feat: 전체 엔드포인트 권한 설정

### DIFF
--- a/api/api-booking/http/booking.http
+++ b/api/api-booking/http/booking.http
@@ -1,11 +1,11 @@
 ### 세션 아이디 발급
 POST http://localhost:8082/api/v1/bookings/issue-session-id
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 
 ### 대기열 진입
 POST http://localhost:8082/api/v1/bookings/enter-queue
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Session-Id: {sessionId}
 
 {
@@ -14,14 +14,14 @@ Booking-Session-Id: {sessionId}
 
 ### 대기열 조회
 GET http://localhost:8082/api/v1/bookings/order-in-queue?eventId=1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Session-Id: {sessionId}
 
 
 ### 예매 토큰 발급
 POST http://localhost:8082/api/v1/bookings/issue-token
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Session-Id: {sessionId}
 
 {
@@ -31,7 +31,7 @@ Booking-Session-Id: {sessionId}
 ### [Optional] 대기열 이탈
 POST http://localhost:8082/api/v1/bookings/exit-queue
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Session-Id: {sessionId}
 
 {
@@ -40,23 +40,23 @@ Booking-Session-Id: {sessionId}
 
 ### 좌석 목록 조회
 GET http://localhost:8082/api/v1/seats?eventTimeId=1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJpc3MiOiJib29raW5nIiwiaWF0IjoxNzA0NzA0NTY0LCJleHAiOjQyMDAxNzA0NzA0NTY0LCJzZXNzaW9uSWQiOiJ7Pz8_Pz99In0.iKZaud5vfvsMzXmQzl1WaCweL9GL00U0iGzCg4_p3Zzei8Y7z19Ff_TTpxh9gLeB
 
 ### 좌석 선택
 POST http://localhost:8082/api/v1/seats/1/select
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJpc3MiOiJib29raW5nIiwiaWF0IjoxNzA0NzA0NTY0LCJleHAiOjQyMDAxNzA0NzA0NTY0LCJzZXNzaW9uSWQiOiJ7Pz8_Pz99In0.iKZaud5vfvsMzXmQzl1WaCweL9GL00U0iGzCg4_p3Zzei8Y7z19Ff_TTpxh9gLeB
 
 {
-    "seatId": 1
+  "seatId": 1
 }
 
 ### 좌석 선택 해제
 POST http://localhost:8082/api/v1/seats/1/deselect
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJpc3MiOiJib29raW5nIiwiaWF0IjoxNzA0NzA0NTY0LCJleHAiOjQyMDAxNzA0NzA0NTY0LCJzZXNzaW9uSWQiOiJ7Pz8_Pz99In0.iKZaud5vfvsMzXmQzl1WaCweL9GL00U0iGzCg4_p3Zzei8Y7z19Ff_TTpxh9gLeB
 
 {
@@ -68,12 +68,12 @@ GET http://localhost:8082/bookings
 
 ### [Optional] 예매 이탈
 POST http://localhost:8082/api/v1/bookings/bookingCreateTestId/exit
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Booking-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJpc3MiOiJib29raW5nIiwiaWF0IjoxNzA0NzA0NTY0LCJleHAiOjQyMDAxNzA0NzA0NTY0LCJzZXNzaW9uSWQiOiJ7Pz8_Pz99In0.iKZaud5vfvsMzXmQzl1WaCweL9GL00U0iGzCg4_p3Zzei8Y7z19Ff_TTpxh9gLeB
 
 ### 예매 취소 (브라우저에서 생성된 예매번호로 진행해 주세요)
 POST http://localhost:8082/api/v1/bookings/{bookingId}/cancel
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -82,8 +82,8 @@ Content-Type: application/json
 
 ### 내 예매 내역 목록 조회
 GET http://localhost:8082/api/v1/bookings
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}
 
 ### 내 예매 내역 상세 조회
 GET http://localhost:8082/api/v1/bookings/bookingCancelTestId
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwic3ViIjoiam9obi5kb2VAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDQ2OTE0OTEsImV4cCI6MTgwNDY4MzI5MSwiYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn0.wFNSz2uwRa35jP1KihNlTOewVLgMMeg3ADQ5Kztl3QQ
+Authorization: Bearer {{token}}

--- a/api/api-event/http/event-hall.http
+++ b/api/api-event/http/event-hall.http
@@ -1,6 +1,7 @@
 ### 공연장 생성
 POST http://localhost:8080/api/v1/event-halls
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 {
   "name" : "잠실 종합운동장",

--- a/api/api-event/http/event-review.http
+++ b/api/api-event/http/event-review.http
@@ -1,6 +1,7 @@
 ### 공연 리뷰 생성
 POST http://localhost:8080/api/v1/event-reviews/1
 Content-Type: application/json
+Authorization: Bearer {{token}}
 
 {
   "score": 2,
@@ -10,6 +11,7 @@ Content-Type: application/json
 ### 공연 리뷰 수정
 PATCH http://localhost:8080/api/v1/event-reviews/1
 Content-Type: application/json
+Authorization: Bearer {{token}}
 
 {
   "content": "amazing Event !!"
@@ -17,10 +19,12 @@ Content-Type: application/json
 
 ### 공연 리뷰 아이디로 조회
 GET http://localhost:8080/api/v1/event-reviews/1
+Authorization: Bearer {{token}}
 
 ### 특정 공연에 대한 리뷰 전체 조회
 GET http://localhost:8080/api/v1/event-reviews/events/1
+Authorization: Bearer {{token}}
 
 ### 리뷰 아이디로 삭제
 DELETE http://localhost:8080/api/v1/event-reviews/1
-
+Authorization: Bearer {{token}}

--- a/api/api-event/http/event-seat.http
+++ b/api/api-event/http/event-seat.http
@@ -1,6 +1,7 @@
 ### 공연 좌석 구역 생성
 POST http://localhost:8080/api/v1/events/1/seat-area
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 {
   "requests" :
@@ -19,6 +20,7 @@ Content-Type: application/json
 ### 공연 좌석 생성
 POST http://localhost:8080/api/v1/event-seats/events/1
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 [
   {

--- a/api/api-event/http/event-time.http
+++ b/api/api-event/http/event-time.http
@@ -2,6 +2,7 @@
 ### 공연 회차 생성
 POST http://localhost:8080/api/v1/event-times/2
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 {
   "round": 1,
@@ -18,6 +19,7 @@ GET http://localhost:8080/api/v1/event-times/events/2
 ### 회차 아이디로 회차 정보 수정
 PATCH http://localhost:8080/api/v1/event-times/2
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 {
   "startedAt": "2024-02-06T12:00:00",
@@ -26,3 +28,4 @@ Content-Type: application/json
 
 ### 회차 아이디로 회차 삭제
 DELETE http://localhost:8080/api/v1/event-times/1
+Authorization: Bearer {{adminToken}}

--- a/api/api-event/http/event.http
+++ b/api/api-event/http/event.http
@@ -1,6 +1,7 @@
 ### 공연 생성
 POST http://localhost:8080/api/v1/events
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 {
   "title": "엘라스틱 서치3",
@@ -30,6 +31,7 @@ GET http://localhost:8080/api/v1/events/sort/ended-at?page=1&size=10&genreType=C
 ### 공연 수정
 PUT http://localhost:8080/api/v1/events/2
 Content-Type: application/json
+Authorization: Bearer {{adminToken}}
 
 {
   "title": "update title22",

--- a/api/api-member/http/test.http
+++ b/api/api-member/http/test.http
@@ -142,7 +142,7 @@ http://localhost:8081/login
 
 ### 멤버 본인 정보 조회 (토큰 필요)
 GET http://localhost:8081/api/v1/members/me
-Authorization: Bearer eyJhbGciOiJIUzM4NCJ9.eyJpZCI6Mywic3ViIjoidGVzdEB0ZXN0LmNvbSIsImlhdCI6MTcwNDc5Mjg3NSwiZXhwIjoxNzA0Nzk0Njc1LCJhdXRob3JpdHkiOiIifQ.pD0WG-Pp33x_di-lBmWxfoCH0PdTv35z3skVDSSgKo0kMp2Iie2GQwvk7XaW_I5u
+Authorization: Bearer {{token}}
 
 ### 멤버 본인 정보 수정 (토큰 필요)
 PATCH http://localhost:8081/api/v1/members/me

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
@@ -53,20 +53,12 @@ public class WebSecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain securityFilterChainPermitAll(HttpSecurity http) throws Exception {
+		configureCommonSecuritySettings(http);
 		http
 			.securityMatchers(matchers -> matchers
 				.requestMatchers(requestPermitAll())
 			)
-			.authorizeHttpRequests().anyRequest().permitAll().and()
-
-			// filter 비활성화
-			.csrf().disable()
-			.anonymous().disable()
-			.formLogin().disable()
-			.httpBasic().disable()
-			.rememberMe().disable()
-			.logout().disable()
-			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+			.authorizeHttpRequests().anyRequest().permitAll();
 		return http.build();
 	}
 
@@ -85,6 +77,7 @@ public class WebSecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain securityFilterChainOAuth(HttpSecurity http) throws Exception {
+		configureCommonSecuritySettings(http);
 		http
 			.securityMatchers(matchers -> matchers
 				.requestMatchers(
@@ -98,16 +91,7 @@ public class WebSecurityConfig {
 				.loginPage("/login")
 				.successHandler(oauthSuccessHandler)
 				.userInfoEndpoint()
-				.userService(oAuth2UserService))
-
-			// 필터 비활성화
-			.csrf().disable()
-			.anonymous().disable()
-			.formLogin().disable()
-			.httpBasic().disable()
-			.rememberMe().disable()
-			.logout().disable()
-			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+				.userService(oAuth2UserService));
 		return http.build();
 	}
 
@@ -116,6 +100,7 @@ public class WebSecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain securityFilterChainAuthorized(HttpSecurity http) throws Exception {
+		configureCommonSecuritySettings(http);
 		http
 			.securityMatchers(matchers -> matchers
 				.requestMatchers(requestHasRoleUser())
@@ -131,16 +116,7 @@ public class WebSecurityConfig {
 				exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
 				exception.accessDeniedHandler(jwtAccessDeniedHandler);
 			})
-			.addFilterAfter(jwtAuthenticationFilter, ExceptionTranslationFilter.class)
-
-			// filter 비활성화
-			.csrf().disable()
-			.anonymous().disable()
-			.formLogin().disable()
-			.httpBasic().disable()
-			.rememberMe().disable()
-			.logout().disable()
-			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+			.addFilterAfter(jwtAuthenticationFilter, ExceptionTranslationFilter.class);
 		return http.build();
 	}
 
@@ -174,22 +150,25 @@ public class WebSecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		configureCommonSecuritySettings(http);
 		http
 			.authorizeHttpRequests().anyRequest().permitAll().and() // TODO 완성 후 denyAll 로 변경, exceptionHandling 삭제하기
 			.exceptionHandling(exception -> {
 				exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
 				exception.accessDeniedHandler(jwtAccessDeniedHandler);
-			})
+			});
+		return http.build();
+	}
 
-			// filter 비활성화
+	private void configureCommonSecuritySettings(HttpSecurity http) throws Exception {
+		http
 			.csrf().disable()
 			.anonymous().disable()
 			.formLogin().disable()
 			.httpBasic().disable()
 			.rememberMe().disable()
 			.logout().disable()
-			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-		return http.build();
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 	}
-
 }

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.pgms.coresecurity.security.config;
 
+import static org.springframework.http.HttpMethod.*;
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.*;
 
 import java.util.List;
@@ -64,10 +65,19 @@ public class WebSecurityConfig {
 
 	private RequestMatcher[] requestPermitAll() {
 		List<RequestMatcher> requestMatchers = List.of(
+			// MEMBER
 			antMatcher("/api/*/auth/**"),
 			antMatcher("/api/*/members/signup"),
+
+			// SWAGGER
 			antMatcher("/v3/api-docs/**"),
-			antMatcher("/swagger-ui/**")
+			antMatcher("/swagger-ui/**"),
+
+			// BOOKING
+			antMatcher(GET, "/api/*/payments/**"),
+			antMatcher(POST, "/api/*/payments/**"),
+			antMatcher("/bookings"),
+			antMatcher("/payments")
 		);
 		return requestMatchers.toArray(RequestMatcher[]::new);
 	}
@@ -141,7 +151,15 @@ public class WebSecurityConfig {
 
 	private RequestMatcher[] requestHasRoleUser() {
 		List<RequestMatcher> requestMatchers = List.of(
-			antMatcher("/api/*/members/**"));
+			// MEMBER
+			antMatcher("/api/*/members/**"),
+
+			// BOOKING
+			antMatcher(GET, "/api/*/bookings/**"),
+			antMatcher(POST, "/api/*/bookings/**"),
+			antMatcher(GET, "/api/*/seats/**"),
+			antMatcher(POST, "/api/*/seats/**")
+		);
 		return requestMatchers.toArray(RequestMatcher[]::new);
 	}
 

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 
 import java.util.List;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -141,6 +142,13 @@ public class WebSecurityConfig {
 			.logout().disable()
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 		return http.build();
+	}
+
+	@Bean
+	public FilterRegistrationBean<JwtAuthenticationFilter> filterRegistration(JwtAuthenticationFilter filter) {
+		FilterRegistrationBean<JwtAuthenticationFilter> registration = new FilterRegistrationBean<>(filter);
+		registration.setEnabled(false);
+		return registration;
 	}
 
 	private RequestMatcher[] requestHasRoleSuperAdmin() {

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.pgms.coresecurity.security.config;
 
+import static com.pgms.coredomain.domain.member.enums.Role.*;
 import static org.springframework.http.HttpMethod.*;
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.*;
 
@@ -20,7 +21,6 @@ import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
-import com.pgms.coredomain.domain.member.enums.Role;
 import com.pgms.coresecurity.security.jwt.JwtAccessDeniedHandler;
 import com.pgms.coresecurity.security.jwt.JwtAuthenticationEntryPoint;
 import com.pgms.coresecurity.security.jwt.JwtAuthenticationFilter;
@@ -133,9 +133,9 @@ public class WebSecurityConfig {
 				.requestMatchers(requestHasRoleSuperAdmin())
 			)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(requestHasRoleSuperAdmin()).hasAuthority(Role.ROLE_SUPERADMIN.name())
-				.requestMatchers(requestHasRoleAdmin()).hasAuthority(Role.ROLE_ADMIN.name())
-				.requestMatchers(requestHasRoleUser()).hasAuthority(Role.ROLE_USER.name()))
+				.requestMatchers(requestHasRoleSuperAdmin()).hasAuthority(ROLE_SUPERADMIN.name())
+				.requestMatchers(requestHasRoleAdmin()).hasAuthority(ROLE_ADMIN.name())
+				.requestMatchers(requestHasRoleUser()).hasAuthority(ROLE_USER.name()))
 			.exceptionHandling(exception -> {
 				exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
 				exception.accessDeniedHandler(jwtAccessDeniedHandler);
@@ -163,23 +163,23 @@ public class WebSecurityConfig {
 			antMatcher("/api/*/admin/**"),
 
 			// EVENT
-			antMatcher(POST, "/api/*/events"),             // 공연 생성
+			antMatcher(POST, "/api/*/events"),                // 공연 생성
 			antMatcher(PUT, "/api/*/events/*"),               // 공연 수정
 			antMatcher(DELETE, "/api/*/events/*"),            // 공연 삭제
 			antMatcher(POST, "/api/*/event-times/*"),         // 공연 회차 생성
 			antMatcher(PATCH, "/api/*/event-times/*"),         // 회차 아이디로 회차 정보 수정
 			antMatcher(DELETE, "/api/*/event-times/*"),        // 회차 아이디로 회차 삭제
-			antMatcher(POST, "/api/*/event-halls"),          // 공연장 생성
-			antMatcher(DELETE, "/api/*/event-halls/*"),       // 공연장 삭제
-			antMatcher(PUT, "/api/*/event-halls/*"),          // 공연장 수정
-			antMatcher(POST, "/api/*/event-seats/events/*"),  // 공연 좌석 생성
+			antMatcher(POST, "/api/*/event-halls"),            // 공연장 생성
+			antMatcher(DELETE, "/api/*/event-halls/*"),        // 공연장 삭제
+			antMatcher(PUT, "/api/*/event-halls/*"),           // 공연장 수정
+			antMatcher(POST, "/api/*/event-seats/events/*"),   // 공연 좌석 생성
 			antMatcher(PATCH, "/api/*/event-seats/seat-area"),   // 공연 좌석 등급 일괄 수정
 			antMatcher(DELETE, "/api/*/event-seats"),            // 공연 좌석 일괄 삭제
 			antMatcher(POST, "/api/*/events/*/seat-area"),       // 공연 좌석 구역 생성
 			antMatcher(DELETE, "/api/*/events/seat-area/*"),     // 공연 좌석 구역 삭제
 			antMatcher(PUT, "/api/*/events/seat-area/*"),        // 공연 좌석 구역 수정
 			antMatcher(POST, "/api/*/thumbnails/events/*"),      // 공연 썸네일 이미지 생성
-			antMatcher(PATCH, "/api/*/thumbnails/events/*"),        // 공연 썸네일 이미지 수정
+			antMatcher(PATCH, "/api/*/thumbnails/events/*"),     // 공연 썸네일 이미지 수정
 			antMatcher(POST, "/api/*/event-images/events/*"),    // 공연 상세 이미지 추가
 			antMatcher(DELETE, "/api/*/event-images/events/*")   // 공연 상세 이미지 삭제
 		);
@@ -208,13 +208,16 @@ public class WebSecurityConfig {
 	}
 
 	/**
-	 * 위에서 정의된 엔드포인트 이외에는 denyAll 로 설정
+	 * 위에서 정의된 엔드포인트 이외에는 authenticated 로 설정
 	 */
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChainDefault(HttpSecurity http) throws Exception {
 		configureCommonSecuritySettings(http);
 		http
-			.authorizeHttpRequests().anyRequest().permitAll().and() // TODO 완성 후 denyAll 로 변경, exceptionHandling 삭제하기
+			.authorizeHttpRequests()
+			.anyRequest().authenticated()
+			.and()
+			.addFilterAfter(jwtAuthenticationFilter, ExceptionTranslationFilter.class)
 			.exceptionHandling(exception -> {
 				exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
 				exception.accessDeniedHandler(jwtAccessDeniedHandler);

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
@@ -69,15 +69,30 @@ public class WebSecurityConfig {
 			antMatcher("/api/*/auth/**"),
 			antMatcher("/api/*/members/signup"),
 
-			// SWAGGER
-			antMatcher("/v3/api-docs/**"),
-			antMatcher("/swagger-ui/**"),
-
 			// BOOKING
 			antMatcher(GET, "/api/*/payments/**"),
 			antMatcher(POST, "/api/*/payments/**"),
 			antMatcher("/bookings"),
-			antMatcher("/payments")
+			antMatcher("/payments"),
+
+			// EVENT
+			antMatcher(GET, "/api/*/events/*"),                // 공연 아이디 조회
+			antMatcher(GET, "/api/*/events/sort/ranking"),    // 공연 목록 조회 - 랭킹순
+			antMatcher(GET, "/api/*/events/sort/review"),    // 공연 목록 조회 - 리뷰순
+			antMatcher(GET, "/api/*/events/sort/ended-at"),    // 공연 목록 조회 - 예약마감일자순
+			antMatcher(GET, "/api/*/events/search/keyword"),    // 공연 키워드 검색
+			antMatcher(GET, "/api/*/events/search/top-ten"),    // 실시간 검색어 순위
+			antMatcher(GET, "/api/*/event-times/*"),    // 회차 아이디로 회차 정보 조회
+			antMatcher(GET, "/api/*/event-times/events/*"),    // 공연 아이디로 특정 공연에 대한 전체 회차 정보 조회
+			antMatcher(GET, "/api/*/event-halls/*"),    // 공연장 아이디 조회
+			antMatcher(GET, "/api/*/event-halls"),    // 공연장 목록 조회
+			antMatcher(GET, "/api/*/event-seats/event-times/*/seats"),    // 회차별 공연 좌석 조회
+			antMatcher(GET, "/api/*/event-seats/event-times/*/available-numbers"),    // 회차별 공연 좌석 구역별 남은 자리 수 조회
+			antMatcher(GET, "/api/*/events/*/seat-area"),    // 공연 좌석 구역 목록 조회
+
+			// DOCS
+			antMatcher("/v3/api-docs/**"),
+			antMatcher("/swagger-ui/**")
 		);
 		return requestMatchers.toArray(RequestMatcher[]::new);
 	}
@@ -118,7 +133,6 @@ public class WebSecurityConfig {
 				.requestMatchers(requestHasRoleSuperAdmin())
 			)
 			.authorizeHttpRequests(auth -> auth
-				// TODO 엔드포인트별 authorize 통합
 				.requestMatchers(requestHasRoleSuperAdmin()).hasAuthority(Role.ROLE_SUPERADMIN.name())
 				.requestMatchers(requestHasRoleAdmin()).hasAuthority(Role.ROLE_ADMIN.name())
 				.requestMatchers(requestHasRoleUser()).hasAuthority(Role.ROLE_USER.name()))
@@ -145,7 +159,30 @@ public class WebSecurityConfig {
 
 	private RequestMatcher[] requestHasRoleAdmin() {
 		List<RequestMatcher> requestMatchers = List.of(
-			antMatcher("/api/*/admin/**"));
+			// MEMBER
+			antMatcher("/api/*/admin/**"),
+
+			// EVENT
+			antMatcher(POST, "/api/*/events"),                        // 공연 생성
+			antMatcher(PUT, "/api/*/events/*"),                        // 공연 수정
+			antMatcher(DELETE, "/api/*/events/*"),                   // 공연 삭제
+			antMatcher(POST, "/api/*/event-times/*"),       // 공연 회차 생성
+			antMatcher(PATCH, "/api/*/event-times/*"),  // 회차 아이디로 회차 정보 수정
+			antMatcher(DELETE, "/api/*/event-times/*"), // 회차 아이디로 회차 삭제
+			antMatcher(POST, "/api/*/event-halls"),                 // 공연장 생성
+			antMatcher(DELETE, "/api/*/event-halls/*"),          // 공연장 삭제
+			antMatcher(PUT, "/api/*/event-halls/*"),             // 공연장 수정
+			antMatcher(POST, "/api/*/event-seats/events/*"),     // 공연 좌석 생성
+			antMatcher(PATCH, "/api/*/event-seats/seat-area"),      // 공연 좌석 등급 일괄 수정
+			antMatcher(DELETE, "/api/*/event-seats"),               // 공연 좌석 일괄 삭제
+			antMatcher(POST, "/api/*/events/*/seat-area"),       // 공연 좌석 구역 생성
+			antMatcher(DELETE, "/api/*/events/seat-area/*"),     // 공연 좌석 구역 삭제
+			antMatcher(PUT, "/api/*/events/seat-area/*"),        // 공연 좌석 구역 수정
+			antMatcher(POST, "/api/*/thumbnails/events/*"), // 공연 썸네일 이미지 생성
+			antMatcher(PATCH, "/api/*/thumbnails/events/*"),// 공연 썸네일 이미지 수정
+			antMatcher(POST, "/api/*/event-images/events/*"),            // 공연 상세 이미지 추가
+			antMatcher(DELETE, "/api/*/event-images/events/*")            // 공연 상세 이미지 삭제
+		);
 		return requestMatchers.toArray(RequestMatcher[]::new);
 	}
 
@@ -158,7 +195,14 @@ public class WebSecurityConfig {
 			antMatcher(GET, "/api/*/bookings/**"),
 			antMatcher(POST, "/api/*/bookings/**"),
 			antMatcher(GET, "/api/*/seats/**"),
-			antMatcher(POST, "/api/*/seats/**")
+			antMatcher(POST, "/api/*/seats/**"),
+
+			// EVENT
+			antMatcher(POST, "/api/*/event-reviews/*"), // 공연 후기 생성
+			antMatcher(PATCH, "/api/*/event-reviews/*"), // 공연 후기 수정
+			antMatcher(GET, "/api/*/event-reviews/*"), // 리뷰 아이디로 조회
+			antMatcher(GET, "/api/*/event-reviews/events/*"), // 특정 공연에 대한 리뷰 전체 조회
+			antMatcher(DELETE, "/api/*/event-reviews/*") // 리뷰 아이디로 삭제
 		);
 		return requestMatchers.toArray(RequestMatcher[]::new);
 	}

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/config/WebSecurityConfig.java
@@ -76,16 +76,16 @@ public class WebSecurityConfig {
 			antMatcher("/payments"),
 
 			// EVENT
-			antMatcher(GET, "/api/*/events/*"),                // 공연 아이디 조회
+			antMatcher(GET, "/api/*/events/*"),               // 공연 아이디 조회
 			antMatcher(GET, "/api/*/events/sort/ranking"),    // 공연 목록 조회 - 랭킹순
-			antMatcher(GET, "/api/*/events/sort/review"),    // 공연 목록 조회 - 리뷰순
-			antMatcher(GET, "/api/*/events/sort/ended-at"),    // 공연 목록 조회 - 예약마감일자순
-			antMatcher(GET, "/api/*/events/search/keyword"),    // 공연 키워드 검색
-			antMatcher(GET, "/api/*/events/search/top-ten"),    // 실시간 검색어 순위
-			antMatcher(GET, "/api/*/event-times/*"),    // 회차 아이디로 회차 정보 조회
-			antMatcher(GET, "/api/*/event-times/events/*"),    // 공연 아이디로 특정 공연에 대한 전체 회차 정보 조회
-			antMatcher(GET, "/api/*/event-halls/*"),    // 공연장 아이디 조회
-			antMatcher(GET, "/api/*/event-halls"),    // 공연장 목록 조회
+			antMatcher(GET, "/api/*/events/sort/review"),     // 공연 목록 조회 - 리뷰순
+			antMatcher(GET, "/api/*/events/sort/ended-at"),   // 공연 목록 조회 - 예약마감일자순
+			antMatcher(GET, "/api/*/events/search/keyword"),  // 공연 키워드 검색
+			antMatcher(GET, "/api/*/events/search/top-ten"),  // 실시간 검색어 순위
+			antMatcher(GET, "/api/*/event-times/*"),             // 회차 아이디로 회차 정보 조회
+			antMatcher(GET, "/api/*/event-times/events/*"),   // 공연 아이디로 특정 공연에 대한 전체 회차 정보 조회
+			antMatcher(GET, "/api/*/event-halls/*"),             // 공연장 아이디 조회
+			antMatcher(GET, "/api/*/event-halls"),             // 공연장 목록 조회
 			antMatcher(GET, "/api/*/event-seats/event-times/*/seats"),    // 회차별 공연 좌석 조회
 			antMatcher(GET, "/api/*/event-seats/event-times/*/available-numbers"),    // 회차별 공연 좌석 구역별 남은 자리 수 조회
 			antMatcher(GET, "/api/*/events/*/seat-area"),    // 공연 좌석 구역 목록 조회
@@ -163,25 +163,25 @@ public class WebSecurityConfig {
 			antMatcher("/api/*/admin/**"),
 
 			// EVENT
-			antMatcher(POST, "/api/*/events"),                        // 공연 생성
-			antMatcher(PUT, "/api/*/events/*"),                        // 공연 수정
-			antMatcher(DELETE, "/api/*/events/*"),                   // 공연 삭제
-			antMatcher(POST, "/api/*/event-times/*"),       // 공연 회차 생성
-			antMatcher(PATCH, "/api/*/event-times/*"),  // 회차 아이디로 회차 정보 수정
-			antMatcher(DELETE, "/api/*/event-times/*"), // 회차 아이디로 회차 삭제
-			antMatcher(POST, "/api/*/event-halls"),                 // 공연장 생성
-			antMatcher(DELETE, "/api/*/event-halls/*"),          // 공연장 삭제
-			antMatcher(PUT, "/api/*/event-halls/*"),             // 공연장 수정
-			antMatcher(POST, "/api/*/event-seats/events/*"),     // 공연 좌석 생성
-			antMatcher(PATCH, "/api/*/event-seats/seat-area"),      // 공연 좌석 등급 일괄 수정
-			antMatcher(DELETE, "/api/*/event-seats"),               // 공연 좌석 일괄 삭제
+			antMatcher(POST, "/api/*/events"),             // 공연 생성
+			antMatcher(PUT, "/api/*/events/*"),               // 공연 수정
+			antMatcher(DELETE, "/api/*/events/*"),            // 공연 삭제
+			antMatcher(POST, "/api/*/event-times/*"),         // 공연 회차 생성
+			antMatcher(PATCH, "/api/*/event-times/*"),         // 회차 아이디로 회차 정보 수정
+			antMatcher(DELETE, "/api/*/event-times/*"),        // 회차 아이디로 회차 삭제
+			antMatcher(POST, "/api/*/event-halls"),          // 공연장 생성
+			antMatcher(DELETE, "/api/*/event-halls/*"),       // 공연장 삭제
+			antMatcher(PUT, "/api/*/event-halls/*"),          // 공연장 수정
+			antMatcher(POST, "/api/*/event-seats/events/*"),  // 공연 좌석 생성
+			antMatcher(PATCH, "/api/*/event-seats/seat-area"),   // 공연 좌석 등급 일괄 수정
+			antMatcher(DELETE, "/api/*/event-seats"),            // 공연 좌석 일괄 삭제
 			antMatcher(POST, "/api/*/events/*/seat-area"),       // 공연 좌석 구역 생성
 			antMatcher(DELETE, "/api/*/events/seat-area/*"),     // 공연 좌석 구역 삭제
 			antMatcher(PUT, "/api/*/events/seat-area/*"),        // 공연 좌석 구역 수정
-			antMatcher(POST, "/api/*/thumbnails/events/*"), // 공연 썸네일 이미지 생성
-			antMatcher(PATCH, "/api/*/thumbnails/events/*"),// 공연 썸네일 이미지 수정
-			antMatcher(POST, "/api/*/event-images/events/*"),            // 공연 상세 이미지 추가
-			antMatcher(DELETE, "/api/*/event-images/events/*")            // 공연 상세 이미지 삭제
+			antMatcher(POST, "/api/*/thumbnails/events/*"),      // 공연 썸네일 이미지 생성
+			antMatcher(PATCH, "/api/*/thumbnails/events/*"),        // 공연 썸네일 이미지 수정
+			antMatcher(POST, "/api/*/event-images/events/*"),    // 공연 상세 이미지 추가
+			antMatcher(DELETE, "/api/*/event-images/events/*")   // 공연 상세 이미지 삭제
 		);
 		return requestMatchers.toArray(RequestMatcher[]::new);
 	}


### PR DESCRIPTION
## 구현 기능
+ 전달주신 내용을 바탕으로 전체 엔드포인트 권한 설정 반영하였습니다.
+ 각 모듈의 http 파일 Authorization 헤더를 추가해놓았습니다.
> 예시 : 공연 생성
> POST http://localhost:8080/api/v1/events
> Content-Type: application/json
> **Authorization: Bearer {{adminToken}}**
> ...

## 사용 방법
http 파일 상단 - Run With - No environment라고 되어있는데
<img width="425" alt="스크린샷 2024-01-11 오후 6 20 00" src="https://github.com/Team-BingBong/BE-05-Bingterpark/assets/69096886/26f6ed77-db54-4f71-b3e5-fb3fb8b03d24">
이걸 dev 또는 prod 로 설정하면 해당 환경에 맞는 마스터 토큰 정보가 매핑됩니다.
<img width="596" alt="스크린샷 2024-01-11 오후 6 20 10" src="https://github.com/Team-BingBong/BE-05-Bingterpark/assets/69096886/7362eb6d-d9ca-480c-bbc2-5cbcc0022846">
실제로 로그인 한 후 토큰을 발급 받아 테스트하고 싶다면, {{token}} 자리에 새로 발급받은 액세스 토큰 정보를 복사 붙여넣기 하면 됩니다!

### 각 모듈별로 테스트 해보고, 문제가 있다면 알려주세요! 😊 

resolve: #160 
