### PR TITLE
fix: oauth 로그인시 refreshToken 정보 저장

### DIFF
--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/service/CustomAuthenticationProvider.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/service/CustomAuthenticationProvider.java
@@ -5,7 +5,6 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -34,11 +33,15 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 		String password = authentication.getCredentials().toString();
 		String accountType = authentication.getDetails().toString();
 
-		UserDetails userDetails;
+		UserDetailsImpl userDetails;
 		if (accountType.equals("member")) {
-			userDetails = memberUserDetailsService.loadUserByUsername(email);
+			userDetails = (UserDetailsImpl)memberUserDetailsService.loadUserByUsername(email);
 		} else {
-			userDetails = adminUserDetailsService.loadUserByUsername(email);
+			userDetails = (UserDetailsImpl)adminUserDetailsService.loadUserByUsername(email);
+		}
+
+		if (userDetails.getProvider() != null) {
+			throw new SecurityCustomException(MemberErrorCode.NOT_ALLOWED_BY_PROVIDER);
 		}
 
 		if (!passwordEncoder.matches(password, userDetails.getPassword())) {

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/service/MemberUserDetailsService.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/service/MemberUserDetailsService.java
@@ -24,9 +24,6 @@ public class MemberUserDetailsService implements UserDetailsService {
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new SecurityCustomException(MemberErrorCode.MEMBER_NOT_FOUND));
-		if (member.isLoginByProvider()) {
-			throw new SecurityCustomException(MemberErrorCode.NOT_ALLOWED_BY_PROVIDER);
-		}
 		return UserDetailsImpl.from(member);
 	}
 }

--- a/core/core-security/src/main/java/com/pgms/coresecurity/security/service/UserDetailsImpl.java
+++ b/core/core-security/src/main/java/com/pgms/coresecurity/security/service/UserDetailsImpl.java
@@ -10,12 +10,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.pgms.coredomain.domain.member.Admin;
 import com.pgms.coredomain.domain.member.Member;
+import com.pgms.coredomain.domain.member.enums.Provider;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class UserDetailsImpl implements UserDetails {
 
 	private Long id;
@@ -23,6 +22,23 @@ public class UserDetailsImpl implements UserDetails {
 	@JsonIgnore
 	private String password;
 	private Collection<? extends GrantedAuthority> authorities;
+	private Provider provider;
+
+	public UserDetailsImpl(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+		this.id = id;
+		this.email = email;
+		this.password = password;
+		this.authorities = authorities;
+	}
+
+	public UserDetailsImpl(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities,
+		Provider provider) {
+		this.id = id;
+		this.email = email;
+		this.password = password;
+		this.authorities = authorities;
+		this.provider = provider;
+	}
 
 	public static UserDetails from(Admin admin) {
 		List<GrantedAuthority> authorities = admin.getRole() != null ?
@@ -35,7 +51,13 @@ public class UserDetailsImpl implements UserDetails {
 		List<GrantedAuthority> authorities = member.getRole() != null ?
 			List.of(new SimpleGrantedAuthority(member.getRole().name()))
 			: null;
-		return new UserDetailsImpl(member.getId(), member.getEmail(), member.getPassword(), authorities);
+		return new UserDetailsImpl(
+			member.getId(),
+			member.getEmail(),
+			member.getPassword(),
+			authorities,
+			member.getProvider()
+		);
 	}
 
 	@Override


### PR DESCRIPTION
## 구현 기능
1. oauth 로그인 성공 -> accessToken, refreshToken 발급
2. refreshToken 을 redis에 저장

## 버그
/api/v1/auth/refresh로 토큰 재발급 하려고 하면
```
{
  "errorCode": "NOT ALLOWED BY PROVIDER",
  "errorMessage": "소셜 로그인 회원은 불가능한 요청입니다."
}
```
에러 발생하는데 확인 부탁드려요~!

소셜 로그인 회원은 비밀번호가 null인 로그인 요청을 보낼 수 없게 validation 처리 해놓은거 같은데,
토큰 재발급도 안됩니다! 

resolve: #185 

