### PR TITLE
fix: 가상 계좌 취소 웹훅 오류 수정

### DIFF
--- a/api/api-booking/src/main/java/com/pgms/apibooking/domain/payment/service/PaymentService.java
+++ b/api/api-booking/src/main/java/com/pgms/apibooking/domain/payment/service/PaymentService.java
@@ -103,6 +103,7 @@ public class PaymentService {
 				booking.updateStatus(BookingStatus.PAYMENT_COMPLETED);
 			}
 			case WAITING_FOR_DEPOSIT -> throw new BookingException(BookingErrorCode.ACCOUNT_TRANSFER_ERROR);
+			case CANCELED -> log.info("Virtual Amount Payment Canceled");
 			default -> throw new BookingException(BookingErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}


### PR DESCRIPTION
## 구현 기능
오류 상황 : 결제 수단이 가상 계좌일 때 결제 취소를 하면 서버 에러 발생

발생 이유: 가상계좌의 상태 변화는 아래와 같다. 즉, 결제 취소를 할 때에도 웹훅이 전송되는데, 그 때의 상태값 `CANCELED`에 대한 처리를 해주지 않아 예외가 발생했습니다. 
![image](https://github.com/Team-BingBong/BE-05-Bingterpark/assets/77001047/51235400-9257-495a-8416-e7c9bb5f0810)

resolve: #242 
